### PR TITLE
Store auth0 in global instance

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -104,7 +104,14 @@ export async function createAuth0Instance(): Promise<Auth0> {
 
 const AUTH0_SERVICE = Symbol();
 
-export function Auth0Service() {
+export default function install(app: any): void {
+    const instance = getAuth0Instance();
+
+    app.provide(AUTH0_SERVICE, instance);
+    app.config.globalProperties.$store = instance;
+}
+
+export function Auth0Service(): void {
     provide(AUTH0_SERVICE, getAuth0Instance())
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,11 @@ import { createApp } from 'vue';
 import App from './App.vue'
 import router from './router'
 
+import Auth0 from './auth/index';
+
 const app = createApp(App);
 
+app.use(Auth0);
 app.use(router);
 
 router.isReady().then(() => {

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -2,3 +2,4 @@ declare module '*.vue' {
   import { createApp } from 'vue'
   export default createApp
 }
+

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -20,7 +20,7 @@
 
 <script>
 import { reactive } from 'vue';
-import { Auth0Service, useAuth0 } from './../auth/index.ts';
+import { useAuth0 } from './../auth/index.ts';
 
 export default {
     name: 'Home',
@@ -30,7 +30,6 @@ export default {
             token: null,
         })
 
-        Auth0Service()
         let $auth = await useAuth0()
 
         function login() {


### PR DESCRIPTION
This commit allows us to use `useAuth0` injector globally without
providing the object first in every views.